### PR TITLE
Fix an overflow error

### DIFF
--- a/docs/types/mapping-types.rst
+++ b/docs/types/mapping-types.rst
@@ -174,7 +174,7 @@ the ``sum`` function iterates over to sum all the values.
         }
 
         function iterate_next(itmap storage self, uint keyIndex) internal view returns (uint r_keyIndex) {
-            keyIndex++;
+            unchecked{keyIndex++;}
             while (keyIndex < self.keys.length && self.keys[keyIndex].deleted)
                 keyIndex++;
             return keyIndex;


### PR DESCRIPTION
Function iterate_start would call iterate_next with a type(uint).max as a parameter keyIndex. In iterate_next keyIndex would be incremented causing an overflow and throwing an error. The program would work with unchecked arithmetic.